### PR TITLE
add fluentd to instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
+
 ## Terraform ##
 *.tfvars
 # Compiled files

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+name = "pypi"
+verify_ssl = true
+
+
+[dev-packages]
+
+
+
+[packages]
+
+"boto3" = "*"
+paramiko = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,249 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "42fbfc5cb61ef7cb548f0c964f61d93eea8ff03436e65c9fe42507c01752b036"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "0",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "16.7.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jan 11 22:59:40 PST 2018; root:xnu-3789.73.8~1/RELEASE_X86_64",
+            "python_full_version": "2.7.11",
+            "python_version": "2.7",
+            "sys_platform": "darwin"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
+        "bcrypt": {
+            "hashes": [
+                "sha256:f9210820ee4818d84658ed7df16a7f30c9fba7d8b139959950acef91745cc0f7",
+                "sha256:b1e8491c6740f21b37cca77bc64677696a3fb9f32360794d57fa8477b7329eda",
+                "sha256:9eced8962ce3b7124fe20fd358cf8c7470706437fa064b9874f849ad4c5866fc",
+                "sha256:346d6f84ff0b493dbc90c6b77136df83e81f903f0b95525ee80e5e6d5e4eef84",
+                "sha256:0f317e4ffbdd15c3c0f8ab5fbd86aa9aabc7bea18b5cc5951b456fe39e9f738c",
+                "sha256:f7fd3ed3745fe6e81e28dc3b3d76cce31525a91f32a387e1febd6b982caf8cdb",
+                "sha256:3b4c23300c4eded8895442c003ae9b14328ae69309ac5867e7530de8bdd7875d",
+                "sha256:34dd60b90b0f6de94a89e71fcd19913a30e83091c8468d0923a93a0cccbfbbff",
+                "sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20",
+                "sha256:6efd9ca20aefbaf2e7e6817a2c6ed4a50ff6900fafdea1bcb1d0e9471743b144",
+                "sha256:f2fe545d27a619a552396533cddf70d83cecd880a611cdfdbb87ca6aec52f66b",
+                "sha256:e22f0997622e1ceec834fd25947dc2ee2962c2133ea693d61805bc867abaf7ea",
+                "sha256:c906bdb482162e9ef48eea9f8c0d967acceb5c84f2d25574c7d2a58d04861df1",
+                "sha256:43d1960e7db14042319c46925892d5fa99b08ff21d57482e6f5328a1aca03588",
+                "sha256:321d4d48be25b8d77594d8324c0585c80ae91ac214f62db9098734e5e7fb280f",
+                "sha256:ae35dbcb6b011af6c840893b32399252d81ff57d52c13e12422e16b5fea1d0fb",
+                "sha256:09a3b8c258b815eadb611bad04ca15ec77d86aa9ce56070e1af0d5932f17642a",
+                "sha256:988cac675e25133d01a78f2286189c1f01974470817a33eaf4cfee573cfb72a5",
+                "sha256:cb18ffdc861dbb244f14be32c47ab69604d0aca415bee53485fcea4f8e93d5ef",
+                "sha256:8629ea6a8a59f865add1d6a87464c3c676e60101b8d16ef404d0a031424a8491",
+                "sha256:a005ed6163490988711ff732386b08effcbf8df62ae93dd1e5bda0714fad8afb",
+                "sha256:d86da365dda59010ba0d1ac45aa78390f56bf7f992e65f70b3b081d5e5257b09",
+                "sha256:8569844a5d8e1fdde4d7712a05ab2e6061343ac34af6e7e3d7935b2bd1907bfd",
+                "sha256:0872eeecdf9a429c1420158500eedb323a132bc5bf3339475151c52414729e70",
+                "sha256:01477981abf74e306e8ee31629a940a5e9138de000c6b0898f7f850461c4a0a5",
+                "sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832",
+                "sha256:9a6fedda73aba1568962f7543a1f586051c54febbc74e87769bad6a4b8587c39",
+                "sha256:054d6e0acaea429e6da3613fcd12d05ee29a531794d96f6ab959f29a39f33391",
+                "sha256:67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d"
+            ],
+            "version": "==3.1.4"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:24f8f919126b8a55ef3be6729243f71ffe4b927408e4a1be4e64671cdb011409",
+                "sha256:06614d6111c0bcc7e76ef699e4caec0de87217180486e43ec2c353d6f01a409d"
+            ],
+            "version": "==1.5.20"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:628994a88d09a1fe7d96e0c4b786302463bdfaff9f829d4a72ebe8d02e8160ba",
+                "sha256:b7c33d79fe4c6b8d15f4191aa6e60e3ac0f290b3ce3a8b4d831f79eddbca7115"
+            ],
+            "version": "==1.8.34"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:5d0d7023b72794ea847725680e2156d1d01bc698a9007fccce46d03c904fe093",
+                "sha256:86903c0afab4a3390170aca61f753f5adad8ffff947030719ee44dedc5b68403",
+                "sha256:7d35678a54da0d3f1bc30e3a58a232043753d57c691875b5a75e4e062793bc9a",
+                "sha256:824cac33906be5c8e976f0d950924d88ec058989ef9cd2f77f5cd53cec417635",
+                "sha256:6ca52651f6bd4b8647cb7dee15c82619de3e13490f8e0bc0620830a2245b51d1",
+                "sha256:a183959a4b1e01d6172aeed356e2523ec8682596075aa6cf0003fe08da959a49",
+                "sha256:9532c5bc0108bd0fe43c0eb3faa2ef98a2db60fc0d4019f106b88d46803dd663",
+                "sha256:96652215ef328262b5f1d5647632bd342ac6b31dfbc495b21f1ab27cb06d621d",
+                "sha256:6c99d19225e3135f6190a3bfce2a614cae8eaa5dcaf9e0705d4ccb79a3959a3f",
+                "sha256:12cbf4c04c1ad07124bfc9e928c01e282feac9ec7dd72a18042d4fc56456289a",
+                "sha256:69c37089ccf10692361c8d14dbf4138b00b46741ffe9628755054499f06ed548",
+                "sha256:b8d1454ef627098dc76ccfd6211a08065e6f84efe3754d8d112049fec3768e71",
+                "sha256:cd13f347235410c592f6e36395ee1c136a64b66534f10173bfa4df1dc88f47d0",
+                "sha256:0640f12f04f257c4467075a804a4920a5d07ef91e11c525fc65d715c08231c81",
+                "sha256:89a8d05b96bdeca8fdc89c5fa9469a357d30f6c066262e92c0c8d2e4d3c53cae",
+                "sha256:a67c430a9bde73ae85b0c885fcf41b556760e42ea74c16dc70431a349989b448",
+                "sha256:7a831170b621e98f45ed1d5758325be19619a593924127a0a47af9a72a117319",
+                "sha256:796d0379102e6da5215acfcd20e8e69cca9d97309215b4ce088fe175b1c2f586",
+                "sha256:0fe3b3d571543a4065059d1d3d6d39f4ca6da0f2207ad13547094522e32ead46",
+                "sha256:678135090c311780382b1dd3f828f715583ea8a69687ed053c047d3cec6625d6",
+                "sha256:f4992cd7b4c867f453d44c213ee29e8fd484cf81cfece4b6e836d0982b6fa1cf",
+                "sha256:6d191fb20138fe1948727b20e7b96582b7b7e676135eabf72d910e10bf7bfa65",
+                "sha256:ec208ca16e57904dd7f4c7568665f80b1f7eb7e3214be014560c28def219060d",
+                "sha256:b3653644d6411bf4bd64c1f2ca3cb1b093f98c68439ade5cef328609bbfabf8c",
+                "sha256:f4719d0bafc5f0a67b2ec432086d40f653840698d41fa6e9afa679403dea9d78",
+                "sha256:87f837459c3c78d75cb4f5aadf08a7104db15e8c7618a5c732e60f252279c7a6",
+                "sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d"
+            ],
+            "markers": "platform_python_implementation != 'PyPy'",
+            "version": "==1.11.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:69285f5615507b6625f89ea1048addd1d9218585fb886eb90bdebb1d2b2d26f5",
+                "sha256:6cb1224da391fa90f1be524eafb375b62baf8d3df9690b32e8cc475ccfccee5e",
+                "sha256:4f385ee7d39ee1ed74f1d6b1da03d0734ea82855a7b28a9e6e88c4091bc58664",
+                "sha256:a5f2c681fd040ed648513939a1dd2242af19bd5e9e79e53b6dcfa33bdae61217",
+                "sha256:fc2208d95d9ecc8032f5e38330d5ace2e3b0b998e42b08c30c35b2ab3a4a3bc8",
+                "sha256:0d39a93cf25edeae1f796bbc5960e587f34513a852564f6345ea4491a86c5997",
+                "sha256:41f94194ae78f83fd94ca94fb8ad65f92210a76a2421169ffa5c33c3ec7605f4",
+                "sha256:7a2409f1564c84bcf2563d379c9b6148c5bc6b0ae46e109f6a7b4bebadf551df",
+                "sha256:55555d784cfdf9033e81f044c0df04babed2aa141213765d960d233b0139e353",
+                "sha256:9a47a80f65f4feaaf8415a40c339806c7d7d867152ddccc6ca87f707c8b7b565",
+                "sha256:6fb22f63e17813f3d1d8e30dd1e249e2c34233ba1d3de977fd31cb5db764c7d0",
+                "sha256:ee245f185fae723133511e2450be08a66c2eebb53ad27c0c19b228029f4748a5",
+                "sha256:9a2945efcff84830c8e237ab037d0269380d75d400a89cc9e5628e52647e21be",
+                "sha256:2cfcee8829c5dec55597826d52c26bc26e7ce39adb4771584459d0636b0b7108",
+                "sha256:33b564196dcd563e309a0b07444e31611368afe3a3822160c046f5e4c3b5cdd7",
+                "sha256:18d0b0fc21f39b35ea469a82584f55eeecec1f65a92d85af712c425bdef627b3",
+                "sha256:d18df9cf3f3212df28d445ea82ce702c4d7a35817ef7a38ee38879ffa8f7e857",
+                "sha256:b984523d28737e373c7c35c8b6db6001537609d47534892de189bebebaa42a47",
+                "sha256:27a208b9600166976182351174948e128818e7fc95cbdba18143f3106a211546",
+                "sha256:28e4e9a97713aa47b5ef9c5003def2eb58aec89781ef3ef82b1c2916a8b0639b",
+                "sha256:a3c180d12ffb1d8ee5b33a514a5bcb2a9cc06cc89aa74038015591170c82f55d",
+                "sha256:8487524a1212223ca6dc7e2c8913024618f7ff29855c98869088e3818d5f6733",
+                "sha256:e4d967371c5b6b2e67855066471d844c5d52d210c36c28d49a8507b96e2c5291"
+            ],
+            "version": "==2.1.4"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6",
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+            ],
+            "version": "==0.14"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+            ],
+            "version": "==2.6"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63",
+                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64"
+            ],
+            "version": "==0.9.3"
+        },
+        "paramiko": {
+            "hashes": [
+                "sha256:8851e728e8b7590989e68e3936c48ee3ca4dad91d29e3d7ff0305b6c5fc582db",
+                "sha256:486f637f0a33a4792e0e567be37426c287efaa8c4c4a45e3216f9ce7fd70b1fc"
+            ],
+            "version": "==2.4.0"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:f81c96761fca60d64b1c9b79ec2e40cf9495a745cf570613079ef324aeb9672b",
+                "sha256:7d626683e3d792cccc608da02498aff37ab4f3dafd8905d6bf755d11f9b26b43",
+                "sha256:e85895087905c65b5b594eb91f7522664c85545b147d5f4d4e7b1b07da8dcbdc",
+                "sha256:5a0db897b311d265cde49615cf783f1c78613138605cdd0f907ecfa5b2aba3ee",
+                "sha256:d5cd6ed995dba16fad0c521cfe31cd2d68400b53fcc2bce93326829be73ab6d1",
+                "sha256:a7efe807c4b83a859e2735c692b92ed7b567cfddc4163763412920041d876c2b",
+                "sha256:b5a9ca48055b9a20f6d1b3d68e38692e5431c86a0f99ea602e61294e891fee5b",
+                "sha256:c07d6e587b2f928366b1f67c09bda026a3e6fcc99e80a744dc67f8fca3895626",
+                "sha256:d84c2aea3cf43780e9e6a19f4e4dddee9f6976519020e64e47c57e5c7a8c3dd2",
+                "sha256:758cb50abddc03e4563fd9e7f03db56e3e87b58c0bd01247360326e5c0c7ffa5",
+                "sha256:0d7f6e959fe53f3960a23d73f35e1fce61348b30915b6664309ca756de7c1f89",
+                "sha256:d258b0a71994f7770599835249cece1caef3c70def868c4915e6e5ca49b67d15"
+            ],
+            "version": "==0.4.2"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226"
+            ],
+            "version": "==2.18"
+        },
+        "pynacl": {
+            "hashes": [
+                "sha256:0bfa0d94d2be6874e40f896e0a67e290749151e7de767c5aefbad1121cad7512",
+                "sha256:1d33e775fab3f383167afb20b9927aaf4961b953d76eeb271a5703a6d756b65b",
+                "sha256:eb2acabbd487a46b38540a819ef67e477a674481f84a82a7ba2234b9ba46f752",
+                "sha256:14339dc233e7a9dda80a3800e64e7ff89d0878ba23360eea24f1af1b13772cac",
+                "sha256:cf6877124ae6a0698404e169b3ba534542cfbc43f939d46b927d956daf0a373a",
+                "sha256:eeee629828d0eb4f6d98ac41e9a3a6461d114d1d0aa111a8931c049359298da0",
+                "sha256:d0eb5b2795b7ee2cbcfcadacbe95a13afbda048a262bd369da9904fecb568975",
+                "sha256:11aa4e141b2456ce5cecc19c130e970793fa3a2c2e6fbb8ad65b28f35aa9e6b6",
+                "sha256:8ac1167195b32a8755de06efd5b2d2fe76fc864517dab66aaf65662cc59e1988",
+                "sha256:d795f506bcc9463efb5ebb0f65ed77921dcc9e0a50499dedd89f208445de9ecb",
+                "sha256:be71cd5fce04061e1f3d39597f93619c80cdd3558a6c9ba99a546f144a8d8101",
+                "sha256:2a42b2399d0428619e58dac7734838102d35f6dcdee149e0088823629bf99fbb",
+                "sha256:73a5a96fb5fbf2215beee2353a128d382dbca83f5341f0d3c750877a236569ef",
+                "sha256:d8aaf7e5d6b0e0ef7d6dbf7abeb75085713d0100b4eb1a4e4e857de76d77ac45",
+                "sha256:2dce05ac8b3c37b9e2f65eab56c544885607394753e9613fd159d5e2045c2d98",
+                "sha256:f5ce9e26d25eb0b2d96f3ef0ad70e1d3ae89b5d60255c462252a3e456a48c053",
+                "sha256:6453b0dae593163ffc6db6f9c9c1597d35c650598e2c39c0590d1757207a1ac2",
+                "sha256:fabf73d5d0286f9e078774f3435601d2735c94ce9e514ac4fb945701edead7e4",
+                "sha256:13bdc1fe084ff9ac7653ae5a924cae03bf4bb07c6667c9eb5b6eb3c570220776",
+                "sha256:8f505f42f659012794414fa57c498404e64db78f1d98dfd40e318c569f3c783b",
+                "sha256:04e30e5bdeeb2d5b34107f28cd2f5bbfdc6c616f3be88fc6f53582ff1669eeca",
+                "sha256:8abb4ef79161a5f58848b30ab6fb98d8c466da21fdd65558ce1d7afc02c70b5f",
+                "sha256:e0d38fa0a75f65f556fb912f2c6790d1fa29b7dd27a1d9cc5591b281321eaaa9"
+            ],
+            "version": "==1.2.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
+                "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca"
+            ],
+            "version": "==2.6.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:23c156ca4d64b022476c92c44bf938bef71af9ce0dcd8fd6585e7bce52f66e47",
+                "sha256:10891b246296e0049071d56c32953af05cea614dca425a601e4c0be35990121e"
+            ],
+            "version": "==0.1.12"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
+        }
+    },
+    "develop": {}
+}

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -32,7 +32,8 @@ resource "aws_security_group" "public" {
 data "template_file" "setup" {
   template = "${file("${path.module}/templates/setup.sh")}"
   vars {
-    incoming_port = "${var.logging_port}"
+    input_port = "${var.logging_port}"
+    input_protocol = "${lower(local.logging_protocol)}"
   }
 }
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -30,13 +30,20 @@ resource "aws_security_group" "public" {
   }
 }
 
+data "template_file" "setup" {
+  template = "${file("${path.module}/templates/setup.sh")}"
+  vars {
+    incoming_port = "${local.logging_port}"
+  }
+}
+
 resource "aws_launch_configuration" "log_forwarding" {
   name_prefix = "log-forwarding-"
   image_id      = "${var.ami_id}"
   instance_type = "t2.micro"
   security_groups = ["${aws_security_group.public.id}"]
   key_name = "${var.key_pair}"
-  user_data = "${file("${path.module}/files/setup.sh")}"
+  user_data = "${data.template_file.setup.rendered}"
 
   # https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#using-with-autoscaling-groups
   lifecycle {

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -1,5 +1,4 @@
 locals {
-  logging_port = 514
   logging_protocol = "TCP"
 }
 
@@ -7,8 +6,8 @@ resource "aws_security_group" "public" {
   vpc_id = "${var.vpc_id}"
 
   ingress {
-    from_port = "${local.logging_port}"
-    to_port = "${local.logging_port}"
+    from_port = "${var.logging_port}"
+    to_port = "${var.logging_port}"
     protocol = "${local.logging_protocol}"
     # TODO change to VPC CIDR
     cidr_blocks = ["${var.ssh_cidr}"]
@@ -33,7 +32,7 @@ resource "aws_security_group" "public" {
 data "template_file" "setup" {
   template = "${file("${path.module}/templates/setup.sh")}"
   vars {
-    incoming_port = "${local.logging_port}"
+    incoming_port = "${var.logging_port}"
   }
 }
 

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -36,6 +36,7 @@ resource "aws_launch_configuration" "log_forwarding" {
   instance_type = "t2.micro"
   security_groups = ["${aws_security_group.public.id}"]
   key_name = "${var.key_pair}"
+  user_data = "${file("${path.module}/files/setup.sh")}"
 
   # https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#using-with-autoscaling-groups
   lifecycle {

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# https://docs.fluentd.org/v1.0/articles/install-by-deb
+
+curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
+
+sudo sh -c 'echo "
+<source>
+  @type syslog
+  port 514
+  bind 0.0.0.0
+  protocol_type tcp
+  tag external
+</source>
+" >> /etc/td-agent/td-agent.conf'
+
+# https://superuser.com/a/892391/102684
+sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/td-agent/embedded/bin/fluentd
+sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/td-agent/embedded/bin/ruby
+
+sudo systemctl start td-agent.service
+sudo systemctl reload td-agent.service

--- a/load_balancing.tf
+++ b/load_balancing.tf
@@ -10,13 +10,13 @@ resource "aws_lb" "log_forwarding" {
 
 resource "aws_lb_target_group" "log_forwarding" {
   vpc_id = "${var.vpc_id}"
-  port = "${local.logging_port}"
+  port = "${var.logging_port}"
   protocol = "${local.logging_protocol}"
 }
 
 resource "aws_lb_listener" "log_forwarding" {
   load_balancer_arn = "${aws_lb.log_forwarding.arn}"
-  port = "${local.logging_port}"
+  port = "${var.logging_port}"
   protocol = "${local.logging_protocol}"
 
   default_action {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "logging_host" {
   value = "${aws_lb.log_forwarding.dns_name}"
 }
+
+output "logging_port" {
+  value = "${var.logging_port}"
+}

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -7,7 +7,7 @@ curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh 
 sudo sh -c 'echo "
 <source>
   @type syslog
-  port 514
+  port ${incoming_port}
   bind 0.0.0.0
   protocol_type tcp
   tag external

--- a/templates/setup.sh
+++ b/templates/setup.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 
+set -e
+
 # https://docs.fluentd.org/v1.0/articles/install-by-deb
 
 curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
 
+# add the external syslog input
+# https://docs.fluentd.org/v1.0/articles/in_syslog
 sudo sh -c 'echo "
 <source>
   @type syslog
-  port ${incoming_port}
+  port ${input_port}
   bind 0.0.0.0
-  protocol_type tcp
+  protocol_type ${input_protocol}
   tag external
 </source>
 " >> /etc/td-agent/td-agent.conf'
 
+# needed to bind the agent to privileged ports
 # https://superuser.com/a/892391/102684
 sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/td-agent/embedded/bin/fluentd
 sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/td-agent/embedded/bin/ruby
 
-sudo systemctl start td-agent.service
-sudo systemctl reload td-agent.service
+sudo systemctl restart td-agent.service

--- a/test/outputs.tf
+++ b/test/outputs.tf
@@ -1,3 +1,7 @@
+output "vpc_id" {
+  value = "${module.network.vpc_id}"
+}
+
 output "logging_host" {
   value = "${module.log_forwarding.logging_host}"
 }

--- a/test/outputs.tf
+++ b/test/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_id" {
 output "logging_host" {
   value = "${module.log_forwarding.logging_host}"
 }
+
+output "logging_port" {
+  value = "${module.log_forwarding.logging_port}"
+}

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,39 @@
+import boto3
+import socket
+import subprocess
+import unittest
+import warnings
+
+class TestLogForwarding(unittest.TestCase):
+
+    def can_connect_to_port(self, host, port):
+        # https://stackoverflow.com/a/20541919
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(2.0)
+        result = s.connect_ex((host, port))
+        s.close()
+        return result == 0
+
+    def get_terraform_output(self, name):
+        cmd = ['terraform', 'output', name]
+        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return result.stdout.decode('utf-8').strip()
+
+    def test_ssh_to_test_instance(self):
+        # workaround for https://github.com/boto/boto3/issues/454
+        warnings.simplefilter('ignore', ResourceWarning)
+
+        vpc_id = self.get_terraform_output('vpc_id')
+        ec2 = boto3.resource('ec2')
+        instances = ec2.instances.filter(Filters=[
+                {'Name': 'instance-state-name', 'Values': ['running']},
+                {'Name': 'vpc-id', 'Values': [vpc_id]}
+        ])
+
+        self.assertEqual(len(list(instances)), 1)
+        for instance in instances:
+            self.assertTrue(self.can_connect_to_port(instance.public_ip_address, 22))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -33,6 +33,9 @@ class TestLogForwarding(unittest.TestCase):
         self.assertGreaterEqual(len(list(instances)), 1)
         return instances
 
+    def get_logging_port(self):
+        return int(self.get_terraform_output('logging_port'))
+
     def test_ssh_listening(self):
         instances = self.get_instances()
         for instance in instances:
@@ -40,12 +43,14 @@ class TestLogForwarding(unittest.TestCase):
 
     def test_syslog_listening(self):
         instances = self.get_instances()
+        logging_port = self.get_logging_port()
         for instance in instances:
-            self.assertTrue(self.can_connect_to_port(instance.public_ip_address, 514))
+            self.assertTrue(self.can_connect_to_port(instance.public_ip_address, logging_port))
 
     def test_syslog_through_lb(self):
         logging_host = self.get_terraform_output('logging_host')
-        self.assertTrue(self.can_connect_to_port(logging_host, 514))
+        logging_port = self.get_logging_port()
+        self.assertTrue(self.can_connect_to_port(logging_host, logging_port))
 
 
 if __name__ == '__main__':

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,8 @@ variable "key_pair" {
 variable "ssh_cidr" {
   default = "0.0.0.0/0"
 }
+
+variable "logging_port" {
+  default = 514
+  description = "Incoming log port"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,6 @@ variable "ssh_cidr" {
 }
 
 variable "logging_port" {
-  default = 514
-  description = "Incoming log port"
+  default = 601
+  description = "Incoming log port. Uses the default for syslog over TCP, as defined by IANA RFC3195. https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=syslog"
 }


### PR DESCRIPTION
With tests confirming connectivity! Note that I'm installing fluentd (technically [`td-agent`](https://docs.fluentd.org/v1.0/articles/install-by-rpm#what-is-td-agent?)) via a shell script in `user_data` just to get it working, but we will likely want to use the Ansible role to build an AMI instead.